### PR TITLE
fix: Lazy sizes use wrong parent fit value

### DIFF
--- a/src/Resources/app/storefront/src/scss/component/_cms-element.scss
+++ b/src/Resources/app/storefront/src/scss/component/_cms-element.scss
@@ -3,3 +3,7 @@
         width: 100%;
     }
 }
+
+.product-image.is-standard {
+    content: 'parent-fit: contain;';
+}

--- a/src/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -38,10 +38,7 @@
         {% set attributes = attributes|merge({'style': inlineStyle}) %}
     {% endif %}
 
-    {% set parentFit = false %}
-    {% if attributes['data-object-fit'] %}
-        {% set parentFit = attributes['data-object-fit'] %}
-    {% endif %}
+    {% set parentFit = parentFit ?? attributes['data-object-fit'] ?? false %}
 
     {% block thumbnail_utility_img %}
         {% if src is not defined %}

--- a/src/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -54,7 +54,7 @@
                 data-srcset="{{ srcsetValue }}"
                 data-sizes="auto"
                 data-aspectratio="{{ ratio }}"
-                {% if fit %}data-parent-fit="{{ parentFit }}"{% endif %}
+                {% if parentFit %}data-parent-fit="{{ parentFit }}"{% endif %}
             {% endif %}
             {% for key, value in attributes %}
                 {{ key }}="{{ value }}"

--- a/src/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -38,6 +38,11 @@
         {% set attributes = attributes|merge({'style': inlineStyle}) %}
     {% endif %}
 
+    {% set parentFit = false %}
+    {% if attributes['data-object-fit'] %}
+        {% set parentFit = attributes['data-object-fit'] %}
+    {% endif %}
+
     {% block thumbnail_utility_img %}
         {% if src is not defined %}
             {% set src = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==' %}
@@ -49,7 +54,7 @@
                 data-srcset="{{ srcsetValue }}"
                 data-sizes="auto"
                 data-aspectratio="{{ ratio }}"
-                data-parent-fit="contain"
+                {% if fit %}data-parent-fit="{{ parentFit }}"{% endif %}
             {% endif %}
             {% for key, value in attributes %}
                 {{ key }}="{{ value }}"


### PR DESCRIPTION
The documentation of lazy sizes parent fit module says you must set the right value or not data attribute to get the right size
https://github.com/aFarkas/lazysizes/tree/gh-pages/plugins/parent-fit#data-parent-fitcontaincoverwidth-usage