### PR TITLE
fix: Safari product-image dont show

### DIFF
--- a/src/Resources/app/storefront/src/scss/component/_cms-element.scss
+++ b/src/Resources/app/storefront/src/scss/component/_cms-element.scss
@@ -3,7 +3,3 @@
         width: 100%;
     }
 }
-
-.product-image.is-standard {
-    content: 'parent-fit: contain;';
-}

--- a/src/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -29,7 +29,7 @@
         {% endif %}
     {% endif %}
 
-    {% set ratio = metaProportion.width|default(1) / metaProportion.height|default(1) %}
+    {% set ratio = metaProportion.width / metaProportion.height|default(1) %}
 
     {% set inlineStyle = "aspect-ratio:" ~ ratio ~ ";" %}
     {% if attributes.style %}
@@ -39,6 +39,9 @@
     {% endif %}
 
     {% set parentFit = parentFit ?? attributes['data-object-fit'] ?? false %}
+    {% if not parentFit and 'product-image' in attributes.class and 'is-standard' in attributes.class %}
+        {% set parentFit = 'contain' %}
+    {% endif %}
 
     {% if not config('FroshLazySizes.config.UseAdvancedRatio') %}
         {% set ratio = max(1, ratio) %}


### PR DESCRIPTION
Safari use the CSS `content` and don't show an image in the product box. I move the product-image fix from CSS to twig. This fixes the issue #20