### PR TITLE
Fix css class enable/disable for multiple classes

### DIFF
--- a/src/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -5,6 +5,7 @@
         {% set lazysizesThroughCss = null %}
         {% for item in [sectionClasses, blockClasses] %}
             {% if item is defined %}
+                {% set item = item|join(' ')|split(' ') %}
                 {% if 'no-lazysizes' in item %}
                     {% set lazysizesThroughCss = false %}
                 {% elseif 'lazysizes' in item %}

--- a/src/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -1,11 +1,14 @@
 {% sw_extends "@Storefront/storefront/utilities/thumbnail.html.twig" %}
 
-{% block thumbnail_utility %}
+{% block thumbnail_utility %}{% apply spaceless %}
     {% if lazysizes is not defined %}
         {% set lazysizesThroughCss = null %}
         {% for item in [sectionClasses, blockClasses] %}
             {% if item is defined %}
+                {# Yes, item is an array!
+                Therefore we need to combine any entry and convert it back to array #}
                 {% set item = item|join(' ')|split(' ') %}
+
                 {% if 'no-lazysizes' in item %}
                     {% set lazysizesThroughCss = false %}
                 {% elseif 'lazysizes' in item %}
@@ -22,4 +25,4 @@
     {% else %}
         {{ parent() }}
     {% endif %}
-{% endblock %}
+{% endapply%}{% endblock %}


### PR DESCRIPTION
If you enter a space separated string for block or section classes and include no-lazysizes or lazysizes this will be skipped. This PR fixes this.